### PR TITLE
Switched to using associated ids rather than titles.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'biola_deploy'
 gem 'biola_frontend_toolkit', '~> 0.4.4'
 gem 'biola_wcms_components', '~> 0.15.0'
 gem 'blazing'
-gem 'buweb_content_models', '~> 0.128.0'
+gem 'buweb_content_models', '~> 0.129.0'
 gem 'jbuilder', '~> 2.0'
 gem 'kaminari-bootstrap'
 gem 'logging', '~> 1.8'  # until blazing is fixed or removed. Version 2.0 conflicts with blazing.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       sass (>= 3.2.19)
     bson (3.2.0)
     builder (3.2.2)
-    buweb_content_models (0.128.0)
+    buweb_content_models (0.129.0)
       aasm (~> 3.3)
       carrierwave-mongoid (~> 0.7)
       carrierwave-roz (~> 0.3)
@@ -327,7 +327,7 @@ DEPENDENCIES
   biola_wcms_components (~> 0.15.0)
   blazing
   bootstrap-sass (~> 3.3.3)
-  buweb_content_models (~> 0.128.0)
+  buweb_content_models (~> 0.129.0)
   coffee-rails (>= 4.1)
   factory_girl_rails
   font-awesome-rails (~> 4.3)

--- a/app/views/shared/_audience_collection_form.html.slim
+++ b/app/views/shared/_audience_collection_form.html.slim
@@ -27,8 +27,8 @@
                   form: ac,
                   attribute: :schools,
                   collection: AudienceCollection.available_schools.compact,
-                  value_method: :to_s,
-                  text_method: :to_s,
+                  value_method: :id,
+                  text_method: :title,
                   multiple: true
 
           - if AudienceCollection.available_student_levels.compact.present?
@@ -62,9 +62,9 @@
                 = wcms_component "forms/multiselect",
                   form: ac,
                   attribute: :majors,
-                  collection: AudienceCollection.available_majors.compact,
-                  value_method: :to_s,
-                  text_method: :to_s,
+                  collection: AudienceCollection.available_majors,
+                  value_method: :id,
+                  text_method: :full_name,
                   multiple: true
 
           - if AudienceCollection.available_housing_statuses.compact.present?
@@ -99,8 +99,8 @@
                   form: ac,
                   attribute: :departments,
                   collection: AudienceCollection.available_departments.compact,
-                  value_method: :to_s,
-                  text_method: :to_s,
+                  value_method: :id,
+                  text_method: :title,
                   multiple: true
 
         .form-footer


### PR DESCRIPTION
Departments, academic programs, and schools are being added to page editions through audience collections as titles. This will inevitably cause an issue later on if a the related objects title is changed. To fix this issue I changed the relationship type so that the objects id is stored rather than the title. Because this is not a real relationship there could still be an issue if the the object is ever deleted but we'll have to decide wether or not thats real threat.