### PR TITLE
adding a hidden field with an empty value clears the site_category_ids field

### DIFF
--- a/app/controllers/page_editions_controller.rb
+++ b/app/controllers/page_editions_controller.rb
@@ -54,7 +54,7 @@ class PageEditionsController < ApplicationController
   end
 
   def update
-    @page_edition.site_categories = []
+    # @page_edition.site_categories = []
     if @error
       flash[:warning] = @error
       render :edit

--- a/app/controllers/page_editions_controller.rb
+++ b/app/controllers/page_editions_controller.rb
@@ -54,7 +54,6 @@ class PageEditionsController < ApplicationController
   end
 
   def update
-    # @page_edition.site_categories = []
     if @error
       flash[:warning] = @error
       render :edit

--- a/app/views/page_editions/edit_partials/_form.html.slim
+++ b/app/views/page_editions/edit_partials/_form.html.slim
@@ -102,6 +102,7 @@
       br
       - if policy(@page_edition).can_change?(:site_category_ids)
         .multi_category_select
+          input name="page_edition[site_category_ids][]" type="hidden" value=""
           = select_tag 'page_edition[site_category_ids]', options_for_select([], @page_edition.site_category_ids), multiple: true, class: "multiselect"
       - else
         .well.well-faux-input


### PR DESCRIPTION
this seems to be how the wcms_component for multi-select works with the department_ids field. 