### PR TITLE
Updating buweb to fix some bugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'biola_deploy'
 gem 'biola_frontend_toolkit', '~> 0.4.4'
 gem 'biola_wcms_components', '~> 0.16.0'
 gem 'blazing'
-gem 'buweb_content_models', '~> 0.139.0'
+gem 'buweb_content_models', '~> 0.140.0'
 gem 'jbuilder', '~> 2.0'
 gem 'kaminari-bootstrap'
 gem 'logging', '~> 1.8'  # until blazing is fixed or removed. Version 2.0 conflicts with blazing.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
       sass (>= 3.2.19)
     bson (3.2.4)
     builder (3.2.2)
-    buweb_content_models (0.139.0)
+    buweb_content_models (0.140.0)
       aasm (~> 3.3)
       carrierwave-mongoid (~> 0.7)
       carrierwave-roz (~> 0.3)
@@ -327,7 +327,7 @@ DEPENDENCIES
   biola_wcms_components (~> 0.16.0)
   blazing
   bootstrap-sass (~> 3.3.3)
-  buweb_content_models (~> 0.139.0)
+  buweb_content_models (~> 0.140.0)
   coffee-rails (>= 4.1)
   factory_girl_rails
   font-awesome-rails (~> 4.4)

--- a/app/policies/menu_policy.rb
+++ b/app/policies/menu_policy.rb
@@ -19,7 +19,7 @@ class MenuPolicy < ApplicationPolicy
   alias :destroy? :create?
 
   def permitted_attributes
-    attrs = [:title, :slug, :site_id, :menu_links_json, page_edition_ids: []]
+    attrs = [:title, :url, :slug, :site_id, :menu_links_json, page_edition_ids: []]
     attrs
   end
 

--- a/app/views/menus/edit_partials/_form.html.slim
+++ b/app/views/menus/edit_partials/_form.html.slim
@@ -6,9 +6,15 @@
       = f.text_field :title, class: 'form-control', autocomplete: :off
 
     .form-group
+      = f.label :url
+      = f.text_field :url, class: 'form-control', autocomplete: :off
+      p.text-muted This will be where the header title links too.
+
+    .form-group
       = f.label :slug
       .pull-right.text-muted = '(manually set)'
       = f.text_field :slug, class: 'form-control', placeholder: 'example-slug', autocomplete: :off
+      p.text-muted This field is currently not being used. You may leave blank.
 
     .form-group
       = f.label :site_id, "Site"


### PR DESCRIPTION
Adding new url field to menu form.

The update to buweb also fixes the issue where saving invalid JSON would clear the form. Now it keeps your changes around and correctly throws a validation error.