### PR TITLE
add some fail safes in case page or site is nil

### DIFF
--- a/app/policies/permissions_policy.rb
+++ b/app/policies/permissions_policy.rb
@@ -4,8 +4,7 @@ class PermissionsPolicy < ApplicationPolicy
   #############################################
   # Generic if a user has this role at all
   def page_admin?
-    user.admin? ||
-    user.has_role?(:page_edition_admin)
+    user.admin?
   end
 
   # States that the user is able to edit at least one page, either through role,
@@ -17,8 +16,8 @@ class PermissionsPolicy < ApplicationPolicy
 
   # States that the user is able to edit this particular page
   def page_editor_for?(page)
-    site_page_editor_for?(page.site) ||
-    page.has_permission_to?(:edit, user)
+    site_page_editor_for?(page.try(:site)) ||
+    (page && page.has_permission_to?(:edit, user))
   end
 
   # Only a page publisher if you have permissions to a page through site or role
@@ -29,7 +28,7 @@ class PermissionsPolicy < ApplicationPolicy
     if page == PageEdition
       site_page_publisher?
     else
-      site_page_editor_for?(page.site)
+      site_page_editor_for?(page.try(:site))
     end
   end
 
@@ -48,13 +47,13 @@ class PermissionsPolicy < ApplicationPolicy
   # States that the user is a page_edition_publisher for this particular site
   def site_page_publisher_for?(site)
     page_admin? ||
-    site.has_permission_to?(:page_edition_publisher, user)
+    (site && site.has_permission_to?(:page_edition_publisher, user))
   end
 
   # States that the user is a page_editor or page_edition_publisher for this particular site
   def site_page_editor_for?(site)
     site_page_publisher_for?(site) ||
-    site.has_permission_to?(:page_edition_editor, user)
+    (site && site.has_permission_to?(:page_edition_editor, user))
   end
 
   #############################################
@@ -77,6 +76,6 @@ class PermissionsPolicy < ApplicationPolicy
 
   def site_admin_for?(site)
     user.admin? ||
-    site.has_permission_to?(:site_admin, user)
+    (site && site.has_permission_to?(:site_admin, user))
   end
 end

--- a/spec/policies/page_edition_policy_spec.rb
+++ b/spec/policies/page_edition_policy_spec.rb
@@ -48,29 +48,6 @@ describe PageEditionPolicy do
       it { expect(subject).to sanction(:destroy)}
     end
 
-    context "user is a page edition admin" do
-      let(:entitlements) { ["urn:biola:apps:wcms:page_edition_admin"] }
-      it { expect(subject).to sanction(:create)}
-      it { expect(subject).to sanction(:new)}
-      it { expect(subject).to sanction(:index)}
-      it { expect(subject).to sanction(:show)}
-      it { expect(subject).to sanction(:edit)}
-      it { expect(subject).to sanction(:update)}
-      it { expect(subject).to sanction(:view_topics)}
-      context "page edition is a draft" do
-        let(:page_state) { "draft" }
-        it { expect(subject).to sanction(:destroy)}
-      end
-      context "page edition is published" do
-        let(:page_state) { "published" }
-        it { expect(subject).not_to sanction(:destroy)}
-      end
-      context "page edition is archived" do
-        let(:page_state) { "archived" }
-        it { expect(subject).not_to sanction(:destroy)}
-      end
-    end
-
     context "user is a page editor" do
       let(:page_permissions) { [Permission.new(actor_id: user.id, actor_type: 'User', ability: :edit)] }
       it { expect(subject).not_to sanction(:create)}
@@ -207,18 +184,6 @@ describe PageEditionPolicy do
       it { expect(subject.can_manage?(:attachments)).to be_truthy }
       it { expect(subject.can_manage?(:audience_collections)).to be_truthy }
       it { expect(subject.can_manage?(:seo)).to be_falsey }
-    end
-
-    context "user is a page edition admin" do
-      let(:entitlements) { ["urn:biola:apps:wcms:page_edition_admin"] }
-      it { expect(subject.can_manage?(nil)).to be_truthy }
-      it { expect(subject.can_manage?(:form)).to be_truthy }
-      it { expect(subject.can_manage?(:activity_logs)).to be_truthy }
-      it { expect(subject.can_manage?(:permissions)).to be_truthy }
-      it { expect(subject.can_manage?(:presentation_data)).to be_truthy }
-      it { expect(subject.can_manage?(:attachments)).to be_truthy }
-      it { expect(subject.can_manage?(:audience_collections)).to be_truthy }
-      it { expect(subject.can_manage?(:seo)).to be_truthy }
     end
 
     context "site has user as a page edition editor" do

--- a/spec/policies/permissions_policy_spec.rb
+++ b/spec/policies/permissions_policy_spec.rb
@@ -84,21 +84,6 @@ describe PermissionsPolicy do
     it { expect( subject.site_admin_for?( site ) ).to be_falsey }
   end
 
-  context 'user has role as a page_edition_admin' do
-    let(:entitlements) { ["urn:biola:apps:wcms:page_edition_admin"] }
-    it { expect( subject.page_admin? ).to be_truthy }
-    it { expect( subject.page_editor? ).to be_truthy }
-    it { expect( subject.page_editor_for?( page_edition ) ).to be_truthy }
-    it { expect( subject.page_publisher_for?( page_edition ) ).to be_truthy }
-    it { expect( subject.site_page_publisher? ).to be_truthy }
-    it { expect( subject.site_page_editor? ).to be_truthy }
-    it { expect( subject.site_page_publisher_for?( site ) ).to be_truthy }
-    it { expect( subject.site_page_editor_for?( site ) ).to be_truthy }
-    it { expect( subject.feature_admin? ).to be_falsey }
-    it { expect( subject.site_admin? ).to be_falsey }
-    it { expect( subject.site_admin_for?( site ) ).to be_falsey }
-  end
-
   context 'site has user as a page_edition_publisher' do
     let(:site_permissions) { [Permission.new(actor_id: user.id, actor_type: 'User', ability: :page_edition_publisher)] }
     it { expect( subject.page_admin? ).to be_falsey }


### PR DESCRIPTION
page_admin? is now only true if user is an admin. We removed the role from access.

I still have some more changes to make on this branch, but this should get things working for John.